### PR TITLE
Only list top-level dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
 Flask==0.10.1
+oauth2client==2.0.1
 -e git+https://github.com/globusonline/globus-sdk-python.git#egg=globus_sdk
-itsdangerous==0.24
-Jinja2==2.8
-MarkupSafe==0.23
-requests==2.9.1
-Werkzeug==0.11.4

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,1 @@
 flake8==2.5.4
-mccabe==0.4.0
-pep8==1.7.0
-pyflakes==1.0.0


### PR DESCRIPTION
Ceases listing dependencies-of-dependencies (i.e. `pip freeze`) in `requirements.txt` and `test-requirements.txt`, per our discussion this morning.

This helps with our messaging a bit (e.g. "look, you just need these three packages to build a portal using Globus Auth!") and will also make updates slightly easier for us while we're building this thing.
