### PR TITLE
Multi-option repository page

### DIFF
--- a/mrdp/templates/repository.jinja2
+++ b/mrdp/templates/repository.jinja2
@@ -13,11 +13,13 @@
   </div>
 
   <p>
-    Select a dataset and click the button to download, or click on the dataset name to browse files in the dataset.
+    Select some dataset(s) to copy/graph to another endpoint
+    <strong>or</strong>
+    click on a dataset name to browse its files.
   </p>
 
   <div class="form-wrapper">
-    <form class="form-inline" role="form" action="{{url_for('download')}}" method="post">
+    <form class="form-inline" role="form" action="{{url_for('submit')}}" method="post">
       <div class="row">
         <div class="col-md-12">
           <table class="table">
@@ -49,19 +51,48 @@
         </div>
       </div>
 
+      <hr>
+
       <div class="row">
-        <div class="form-group col-md-5">
-          <label class="col-md-4" for="year_filter">Select Year</label>
-          <select class="col-md-3" name="year_filter">
-            {%for year in range(1951, 2016)%}
-              <option value="{{year}}">{{year}}</option>
-            {%endfor%}
-          </select>
+        <div class="form-group col-md-6">
+          <label class="col-md-5" for="year_filter">Filter by Year</label>
+
+          <div class="col-md-5">
+            <select name="year_filter" id="year_filter">
+              <option value="all">all years</option>
+
+              {%for year in range(1951, 2016)%}
+                <option value="{{year}}">{{year}}</option>
+              {%endfor%}
+            </select>
+          </div>
+        </div>
+
+        <div class="form-actions col-md-6 pull-right">
+          <input name="copy" type="submit" class="btn btn-primary"
+                 value="Copy to Another Endpoint">
         </div>
       </div>
-      <br />
-      <div class="form-actions">
-        <input type="submit" class="btn btn-lg btn-primary" value="Download with Globus" />&nbsp;&nbsp;&nbsp;
+
+      <hr>
+
+      <div class="row">
+        <div class="form-group col-md-6">
+          <label class="col-md-5" for="graph_type">Graph Type</label>
+
+          <div class="col-md-5">
+            <select name="graph_type" id="graph_type">
+              <option value="all">both types</option>
+              <option value="precipitation">precipitation</option>
+              <option value="temperature">temperature</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="form-actions col-md-6 pull-right">
+          <input name="graph" type="submit" class="btn btn-primary"
+                 value="Graph to An Endpoint">
+        </div>
       </div>
     </form>
    </div> <!-- form -->

--- a/mrdp/views.py
+++ b/mrdp/views.py
@@ -163,7 +163,7 @@ def repository():
     - Check that we have an authenticated user (i.e. don't allow
       unauthenticated users to access the repository)
     - Get a list of the datasets in the repository
-    - Display a dataset list so user can browse/select to download
+    - Display a dataset list so user can browse/select
 
     The target template (repository.jinja2) expects 'datasets'
     (list of dictionaries) that describe each dataset as:
@@ -176,9 +176,15 @@ def repository():
     return render_template('repository.jinja2', datasets=datasets)
 
 
-@app.route('/download', methods=['POST'])
+@app.route('/submit', methods=['POST'])
 @authenticated
-def download():
+def submit():
+    return copy() if 'copy' in request.form \
+           else graph() if 'graph' in request.form \
+           else abort(404)
+
+
+def copy():
     """
     Add code here to:
 
@@ -200,6 +206,28 @@ def download():
     flash(task_id)
 
     return(redirect(url_for('transfer_status', task_id=task_id)))
+
+
+def graph():
+    """
+    Add code here to:
+
+    - Send to Globus to select a destination endpoint
+    - `GET` all years CSVs for the selected datasets via HTTPS server
+    - Generate a graph SVG/HTML file for the precipitation (`PRCP`),
+      temperature (`TMIN`/`TMAX`), or both, depending on the user's
+      selection, for each dataset
+    - `PUT` the generated graphs onto the user's destination endpoint
+    - Display a confirmation message
+    """
+
+    # Get a list of the selected datasets
+    # e.g. datasets = request.form.getlist('dataset')
+
+    # Get the graph type(s) to generate
+    # e.g. graph_type = request.form.get('graph_type')
+
+    abort(501)
 
 
 @app.route('/browse/<dataset_id>', methods=['GET'])


### PR DESCRIPTION
Breaks the form on this page into two sections, one for copying the selected datasets to another endpoint and the other for actually graphing them.

Because we need the checked/unchecked state of the individual datasets in the table, we must continue to use a single `<form>` that wraps both the table and the actual form controls below.
