### PR TITLE
Genericize use of flashed messages

### DIFF
--- a/mrdp/templates/header.jinja2
+++ b/mrdp/templates/header.jinja2
@@ -9,3 +9,13 @@
     </div>
   </div>
 </header>
+
+{%with messages = get_flashed_messages()%}
+  {%if messages%}
+    <ul class="alert alert-success container">
+      {%for message in messages%}
+        <li>{{message}}</li>
+      {%endfor%}
+    </ul>
+  {%endif%}
+{%endwith%}

--- a/mrdp/templates/transfer_status.jinja2
+++ b/mrdp/templates/transfer_status.jinja2
@@ -11,14 +11,6 @@
     <h1>Transfer Status</h1>
   </div>
 
-  {%with messages = get_flashed_messages()%}
-    {%if messages%}
-      <p>
-        Transfer request submitted successfully. Task ID: {{messages[0]}}
-      </p>
-    {%endif%}
-  {%endwith%}
-
   <p>
     <strong>Task ID</strong>: {{task["task_id"]}}
   </p>

--- a/mrdp/views.py
+++ b/mrdp/views.py
@@ -101,6 +101,7 @@ def profile():
 
             session['has_profile'] = True
 
+            flash("Thank you! Your profile has been successfully updated.")
             return redirect(url_for('profile'))
         else:
             return redirect(url_for('login'))
@@ -270,8 +271,7 @@ def copy():
 
     task_id = transfer.submit_transfer(transfer_data).data['task_id']
 
-    flash(task_id)
-
+    flash("Transfer request submitted successfully. Task ID: " + task_id)
     return(redirect(url_for('transfer_status', task_id=task_id)))
 
 


### PR DESCRIPTION
Use already-human-readable messages in calls to `flash()` and move the template usage to a more global place.
