### PR TITLE
Drop GAE app and replace w/ actual HTTPS endpoint

### DIFF
--- a/mrdp/mrdp.conf
+++ b/mrdp/mrdp.conf
@@ -10,10 +10,11 @@ SECRET_KEY = '=.DKwWzDd}!3}6yeAY+WTF#W:zt5msTI7]2`o}Y!ziU!#CYD+;T9JpW$ud|5C_3'
 DATABASE = './mrdp/data/app.db'
 
 DATASETS= './mrdp/data/datasets.json'
-DATASET_ENDPOINT_ID = 'ba4dd9d6-f2ae-11e5-983a-22000b9da45e'
+DATASET_ENDPOINT_ID = '30ed71b0-fc1d-11e5-a700-22000bf2d559'
+DATASET_ENDPOINT_BASE = '/mrdp/catalog/'
 
-GRAPH_ENDPOINT_ID = 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'  # FIXME
-GRAPH_ENDPOINT_BASE = '/~/'  # FIXME (should probably just be `/`)
+GRAPH_ENDPOINT_ID = '30ed71b0-fc1d-11e5-a700-22000bf2d559'
+GRAPH_ENDPOINT_BASE = '/mrdp/processed/'
 
 GA_CLIENT_ID = '82d3ab26-f8da-42fa-9f19-bcd5e7abb668'
 GA_CLIENT_SECRET = 'QmUvb1lZbzJ6W1UuS29aJHQ0UVYyPD0lOHtle0pSLUVDez5iZkIydUo9N3E8'


### PR DESCRIPTION
- moves the catalog stuff to `/mrdp/catalog/` on the HTTPS endpoint;
  introduces a `DATASET_ENDPOINT_BASE` so this path prefix can be used
  throughout the code
- graph processing still needs to be fixed to happen under the context
  of the portal user, but if you run this as one of our IDs, it will
  work except for the file PUTs
