### PR TITLE
Do not use slashes in dataset names

### DIFF
--- a/mrdp/data/datasets.json
+++ b/mrdp/data/datasets.json
@@ -15,7 +15,7 @@
         "path": "dataset_bwi"
     },
     {
-        "name": "Dallas/Fort Worth International Airport Climate Data",
+        "name": "Dallas-Fort Worth International Airport Climate Data",
         "id": "0a6690dc-8489-4df6-8cca-4f5029a65e1b",
         "path": "dataset_dfw"
     },


### PR DESCRIPTION
Because we use the dataset name to form the destination path name when
doing transfers, "Dallas/Fort Wort" literally will create a "Dallas"
directory, which is unexpected.
