### PR TITLE
Error handling for HTTPS Server interactions

### DIFF
--- a/mrdp/views.py
+++ b/mrdp/views.py
@@ -360,8 +360,8 @@ def graph():
             raise
 
     for filename, svg in svgs.items():
-        # TODO Does the HTTPS server throw an error for an already-existing
-        # destination file, or is it silently overwritten?
+        # n.b. The HTTPS Server will overwrite existing files that you PUT.
+
         requests.put('%s%s%s.svg' % (dest_https, dest_path, filename),
                      data=svg,
                      verify=False,  # FIXME

--- a/mrdp/views.py
+++ b/mrdp/views.py
@@ -330,7 +330,6 @@ def graph():
         source_path = dataset['path']
         response = requests.get('%s%s%s/%s.csv' % (source_https, source_base,
                                                    source_path, selected_year),
-                                verify=False,  # FIXME
                                 headers=dict(
                                     Authorization='Bearer ' + source_token,
                                 ),
@@ -364,7 +363,6 @@ def graph():
 
         requests.put('%s%s%s.svg' % (dest_https, dest_path, filename),
                      data=svg,
-                     verify=False,  # FIXME
                      headers=dict(
                         Authorization='Bearer ' + dest_token,
                      ),

--- a/mrdp/views.py
+++ b/mrdp/views.py
@@ -335,6 +335,7 @@ def graph():
                                     Authorization='Bearer ' + source_token,
                                 ),
                                 allow_redirects=False)
+        response.raise_for_status()
         svgs.update(render_graphs(
             csv_data=response.iter_lines(decode_unicode=True),
             append_titles=" from %s for %s" % (dataset['name'], selected_year),
@@ -367,7 +368,7 @@ def graph():
                      headers=dict(
                         Authorization='Bearer ' + dest_token,
                      ),
-                     allow_redirects=False)
+                     allow_redirects=False).raise_for_status()
 
     flash("%d-file SVG upload to %s on %s completed!" %
           (len(svgs), dest_path, dest_info['display_name']))


### PR DESCRIPTION
- re-enable SSL certification verification (HTTPS Server now has a valid certificate)
- document handling of PUTs for existing files (they are overwritten)
- verify that `requests` calls yield 200 responses so we do not have silent upload failures