### PR TITLE
Add documentation around refresh tokens

### DIFF
--- a/mrdp/mrdp.conf
+++ b/mrdp/mrdp.conf
@@ -24,5 +24,72 @@ GA_TOKEN_URI = 'https://auth.globus.org/v2/oauth2/token'
 GA_REVOKE_URI = 'https://auth.globus.org/v2/oauth2/token/revoke'
 GA_LOGOUT_URI = 'https://auth.globus.org/v2/web/logout'
 
+
+# Our demo web app uses refresh tokens to obtain access tokens for making API
+# calls to Globus services on behalf of the identity of the portal itself
+# rather than that of the logged-in user. These refresh tokens can be retrieved
+# ahead-of-time out-of-band by following these steps:
+#
+# 1. identify your
+#    a. whitelisted development redirect URI that does not currently have
+#       a listening server, e.g. `https://localhost:5000/authcallback`, and
+#    b. scope, e.g. `urn:globus:auth:scope:transfer.api.globus.org:all`
+#
+# 2. activate your virtual environment and start a Python REPL, e.g.
+#
+#        ~/Repos/globus-sdp$ source env/bin/activate
+#
+#        (env) ~/Repos/globus-sdp$ python
+#        Python 2.7.11 (default, Mar 31 2016, 06:18:34)
+#        [GCC 5.3.0] on linux2
+#        Type "help", "copyright", "credits" or "license" for more information.
+#        >>>
+#
+# 3. obtain an authorization URL, e.g.
+#
+#        >>> from oauth2client import client
+#        >>> from mrdp import app
+#        >>> from mrdp.utils import basic_auth_header
+#        >>>
+#        >>> config = app.config
+#        >>> flow = client.OAuth2WebServerFlow(  # TODO simplify w/ other OAuth calls?
+#        ...     client_id=config['GA_CLIENT_ID'],
+#        ...     client_secret=config['GA_CLIENT_SECRET'],
+#        ...     scope='urn:globus:auth:scope:transfer.api.globus.org:all',
+#        ...     auth_uri=config['GA_AUTH_URI'],
+#        ...     redirect_uri='https://localhost:5000/authcallback',
+#        ...     token_uri=config['GA_TOKEN_URI'],
+#        ...     authorization_header=basic_auth_header(),
+#        ... )
+#        >>> flow.step1_get_authorize_url()
+#        'https://auth.globus.org/v2/oauth2/authorize?scope=urn%3Aglobus%3Aauth%3Ascope%3Atransfer.api.globus.org%3Aall&redirect_uri=https%3A%2F%2Flocalhost%3A5000%2Fauthcallback&response_type=code&client_id=82d3ab26-f8da-42fa-9f19-bcd5e7abb668&access_type=offline'
+#
+# 4. open this URL in a new incognito/private-browsing web browser window
+#
+# 5. follow the login steps, using the identity of the portal to login
+#
+# 6. at the end of the process, Globus Auth will redirect back to your
+#    redirect URI with a code on the query string that you should copy to your
+#    clipboard, e.g. `uRoeWFlIT8ifkLemdGfqda0oXYU0u7` is the code from the URL
+#    `https://localhost:5000/authcallback?code=uRoeWFlIT8ifkLemdGfqda0oXYU0u7`
+#
+# 7. use this code in your Python REPL to get back a refresh token, e.g.
+#
+#        >>> credentials = flow.step2_exchange('uRoeWFlIT8ifkLemdGfqda0oXYU0u7')
+#        >>> credentials.refresh_token
+#        u'AQEAAAAAAAMHMhQkuy3WqKiyOm2yjQBV6xEeDLItSEUzPwUD00-vLHb8x5I1rydE9rJpE-UmFu1G5vDVnFpn'
+#
+# 8. store this code in your application
+#
+# 9. repeat these steps for other scopes you need, e.g.
+#
+#        urn:globus:auth:scope:tutorial-https-endpoint.globus.org:all
+#        urn:globus:auth:scope:demo-resource-server:all
+#
+# Globus may grant certain organizations' clients access to use two-legged
+# username/password-based authentication with OAuth for certain identity
+# providers, which provides an alternative way to retrieve an access tokens
+# for calls you app may need to make. Contact us for more information.
+
 PORTAL_REFRESH_TOKEN_TRANSFER = 'AQEAAAAAAAMfZ8foWwsHQMK7vTmoOY2XpYipIoy5IMNlpgNc7Jew0QZE2PIaDUJ4vH9mtCP8Ny431sJuWhht'
 PORTAL_REFRESH_TOKEN_HTTPS = 'AQEAAAAAAAMfaoAiJEOjBqHZbToDqQg_2uxwVLEPXCy5yfxD-wNLlV6oz8eIA9JXIKWEDtgh-zcJ4aqf7lX2'


### PR DESCRIPTION
In the configuration file, adds documentation immediately above the refresh tokens explaining what they are, how to get them ahead-of-time and out-of-band, and the two-legged password grant alternative.