### PR TITLE
Handle errors during authentication

### DIFF
--- a/portal/templates/header.jinja2
+++ b/portal/templates/header.jinja2
@@ -10,12 +10,4 @@
   </div>
 </header>
 
-{%with messages = get_flashed_messages()%}
-  {%if messages%}
-    <ul class="alert alert-success container">
-      {%for message in messages%}
-        <li>{{message}}</li>
-      {%endfor%}
-    </ul>
-  {%endif%}
-{%endwith%}
+{%include 'messages.jinja2'%}

--- a/portal/templates/home.jinja2
+++ b/portal/templates/home.jinja2
@@ -21,6 +21,8 @@
 
 <!-- Main Content -->
 <div class="container">
+  {%include 'messages.jinja2'%}
+
   <div class="row">
     <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
       <div class="post-preview">

--- a/portal/templates/messages.jinja2
+++ b/portal/templates/messages.jinja2
@@ -1,0 +1,9 @@
+{%with messages = get_flashed_messages()%}
+  {%if messages%}
+    <ul class="alert alert-success container">
+      {%for message in messages%}
+        <li>{{message}}</li>
+      {%endfor%}
+    </ul>
+  {%endif%}
+{%endwith%}

--- a/portal/views.py
+++ b/portal/views.py
@@ -124,8 +124,9 @@ def authcallback():
     # If we're coming back from Globus Auth in an error state, the error
     # will be in the "error" query string parameter.
     if 'error' in request.args:
-        pass
-        # handle error
+        flash("You could not be logged into the portal: " +
+              request.args.get('error_description', request.args['error']))
+        return redirect(url_for('home'))
 
     # Set up our Globus Auth/OAuth2 state
 


### PR DESCRIPTION
- fixes `authcallback` to bump back to the home page and flash a message
  on authentication error; uses `error_description` over just `error` if
  available
- breaks messages out into its own template and add it to the home page
  so the flashed error can be displayed after authentication failure
  (the home page is the only unauthenticated-OK route we have for this)