### PR TITLE
Consolidate and rename run scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Simple web app framework for the exercises in the GlobusWorld developer workshop
 
 ##### Running the Portal App
 
-* `./run_app.sh`
+* `./run_portal.py`
 
 ### Linux (Ubuntu)
 
@@ -35,7 +35,7 @@ Simple web app framework for the exercises in the GlobusWorld developer workshop
 
 ##### Running the Portal App
 
-* `./run_app.sh`
+* `./run_portal.py`
 
 ### Windows
 
@@ -52,4 +52,4 @@ Simple web app framework for the exercises in the GlobusWorld developer workshop
 
 ##### Running the Portal App
 
-* `python runportal.py`
+* `python run_portal.py`

--- a/run_app.sh
+++ b/run_app.sh
@@ -1,1 +1,0 @@
-python runportal.py

--- a/run_portal.py
+++ b/run_portal.py
@@ -1,4 +1,6 @@
-from service import app
+#!/usr/bin/env python
+
+from portal import app
 
 if __name__ == '__main__':
     app.run(host='localhost',

--- a/run_service.py
+++ b/run_service.py
@@ -1,4 +1,6 @@
-from portal import app
+#!/usr/bin/env python
+
+from service import app
 
 if __name__ == '__main__':
     app.run(host='localhost',

--- a/run_service.sh
+++ b/run_service.sh
@@ -1,1 +1,0 @@
-python runrs.py


### PR DESCRIPTION
- refer to these as "portal" and "service", like the package names
- eliminates the bash/sh scripts in favor of just having `run_portal.py`
  and `run_service.py` scripts, which are now executable and contain a
  leading shebang for Python