### PR TITLE
Use straight quotes in JSON example

### DIFF
--- a/service/utils.py
+++ b/service/utils.py
@@ -34,10 +34,10 @@ def token_introspect(token):
     #     "exp": 1419356238,
     #     "iat": 1419350238,
     #     "nbf": 1419350238,
-    #     “identities_set”: [“2982f207-04c0-11e5-ac60-22000b92c6ec”,
-    #     ”3982f207-04c0-11e5-ac60-22000b92c6ed”]
-    #     “name”: “Joe User”,
-    #     “email”: “user1@example.dom”
+    #     "identities_set": ["2982f207-04c0-11e5-ac60-22000b92c6ec",
+    #                        "3982f207-04c0-11e5-ac60-22000b92c6ed"]
+    #     "name": "Joe User",
+    #     "email": "user1@example.dom"
     # }
 
     return token_data.json()


### PR DESCRIPTION
If I try to run the service package right now, I get:

> SyntaxError: Non-ASCII character '\xe2' in file /home/mayor/Repos/globus-sdp/service/utils.py on line 37, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

... but perhaps better than declaring an encoding would be to only have straight quotes in sample JSON bodies.