### PR TITLE
Use client secrets JSON file for Auth config

### DIFF
--- a/portal/auth.json
+++ b/portal/auth.json
@@ -1,0 +1,11 @@
+{
+  "web": {
+    "client_id": "82d3ab26-f8da-42fa-9f19-bcd5e7abb668",
+    "client_secret": "QmUvb1lZbzJ6W1UuS29aJHQ0UVYyPD0lOHtle0pSLUVDez5iZkIydUo9N3E8",
+    "redirect_uris": ["https://localhost:5000/authcallback"],
+    "auth_uri": "https://auth.globus.org/v2/oauth2/authorize",
+    "token_uri": "https://auth.globus.org/v2/oauth2/token",
+    "revoke_uri": "https://auth.globus.org/v2/oauth2/token/revoke",
+    "logout_uri": "https://auth.globus.org/v2/web/logout"
+  }
+}

--- a/portal/portal.conf
+++ b/portal/portal.conf
@@ -16,13 +16,8 @@ DATASET_ENDPOINT_BASE = '/portal/catalog/'
 GRAPH_ENDPOINT_ID = '30ed71b0-fc1d-11e5-a700-22000bf2d559'
 GRAPH_ENDPOINT_BASE = '/portal/processed/'
 
-GA_CLIENT_ID = '82d3ab26-f8da-42fa-9f19-bcd5e7abb668'
-GA_CLIENT_SECRET = 'QmUvb1lZbzJ6W1UuS29aJHQ0UVYyPD0lOHtle0pSLUVDez5iZkIydUo9N3E8'
-GA_REDIRECT_URI = 'https://localhost:5000/authcallback'
-GA_AUTH_URI = 'https://auth.globus.org/v2/oauth2/authorize'
-GA_TOKEN_URI = 'https://auth.globus.org/v2/oauth2/token'
-GA_REVOKE_URI = 'https://auth.globus.org/v2/oauth2/token/revoke'
-GA_LOGOUT_URI = 'https://auth.globus.org/v2/web/logout'
+import json
+GLOBUS_AUTH = json.load(open('portal/auth.json'))['web']
 
 
 # Our demo web app uses refresh tokens to obtain access tokens for making API
@@ -51,15 +46,10 @@ GA_LOGOUT_URI = 'https://auth.globus.org/v2/web/logout'
 #        >>> from portal import app
 #        >>> from portal.utils import basic_auth_header
 #        >>>
-#        >>> config = app.config
-#        >>> flow = client.OAuth2WebServerFlow(  # TODO simplify w/ other OAuth calls?
-#        ...     client_id=config['GA_CLIENT_ID'],
-#        ...     client_secret=config['GA_CLIENT_SECRET'],
+#        >>> flow = client.flow_from_clientsecrets(
+#        ...     'portal/auth.json',
 #        ...     scope='urn:globus:auth:scope:transfer.api.globus.org:all',
-#        ...     auth_uri=config['GA_AUTH_URI'],
 #        ...     redirect_uri='https://localhost:5000/authcallback',
-#        ...     token_uri=config['GA_TOKEN_URI'],
-#        ...     authorization_header=basic_auth_header(),
 #        ... )
 #        >>> flow.step1_get_authorize_url()
 #        'https://auth.globus.org/v2/oauth2/authorize?scope=urn%3Aglobus%3Aauth%3Ascope%3Atransfer.api.globus.org%3Aall&redirect_uri=https%3A%2F%2Flocalhost%3A5000%2Fauthcallback&response_type=code&client_id=82d3ab26-f8da-42fa-9f19-bcd5e7abb668&access_type=offline'

--- a/portal/utils.py
+++ b/portal/utils.py
@@ -13,8 +13,9 @@ from portal import app
 
 def basic_auth_header():
     """Generate a Globus Auth compatible basic auth header."""
-    cid = app.config['GA_CLIENT_ID']
-    csecret = app.config['GA_CLIENT_SECRET']
+    auth_config = app.config['GLOBUS_AUTH']
+    cid = auth_config['client_id']
+    csecret = auth_config['client_secret']
 
     creds = '{}:{}'.format(cid, csecret)
     basic_auth = urlsafe_b64encode(creds.encode(encoding='UTF-8'))
@@ -68,7 +69,7 @@ def get_portal_tokens():
                 refresh_token = app.config['PORTAL_REFRESH_TOKEN_' +
                                            service.upper()]
                 get_portal_tokens.access_tokens[service] = requests.post(
-                    app.config['GA_TOKEN_URI'],
+                    app.config['GLOBUS_AUTH']['token_uri'],
                     data=dict(grant_type='refresh_token',
                               refresh_token=refresh_token),
                     headers=dict(Authorization=basic_auth_header()),


### PR DESCRIPTION
@jaswilli We talked about going full-hog with the Google library and using `flow_from_clientsecrets()` once the patched Auth went out, but doing this adds some configuration complexity, so it's totally at your discretion if you want this.

-----

This enables the use of the simpler `flow_from_clientsecrets()` function for creating a Google OAuth2 "flow" object based on the configuration stored in `auth.json`.

Because we still have some custom calls (notably logout) that also needs access to the same Auth configuration information, it is re-exported via `GLOBUS_AUTH` in the Flask `app.config` lookup.