### PR TITLE
Do portal refresh tokens via the oauth2client lib

### DIFF
--- a/portal/portal.conf
+++ b/portal/portal.conf
@@ -22,8 +22,8 @@ GLOBUS_AUTH = json.load(open('portal/auth.json'))['web']
 
 # Our demo web app uses refresh tokens to obtain access tokens for making API
 # calls to Globus services on behalf of the identity of the portal itself
-# rather than that of the logged-in user. These refresh tokens can be retrieved
-# ahead-of-time out-of-band by following these steps:
+# rather than that of the logged-in user. The credentials for these can be
+# retrieved ahead-of-time out-of-band by following these steps:
 #
 # 1. identify your
 #    a. whitelisted development redirect URI that does not currently have
@@ -43,9 +43,6 @@ GLOBUS_AUTH = json.load(open('portal/auth.json'))['web']
 # 3. obtain an authorization URL, e.g.
 #
 #        >>> from oauth2client import client
-#        >>> from portal import app
-#        >>> from portal.utils import basic_auth_header
-#        >>>
 #        >>> flow = client.flow_from_clientsecrets(
 #        ...     'portal/auth.json',
 #        ...     scope='urn:globus:auth:scope:transfer.api.globus.org:all',
@@ -63,13 +60,13 @@ GLOBUS_AUTH = json.load(open('portal/auth.json'))['web']
 #    clipboard, e.g. `uRoeWFlIT8ifkLemdGfqda0oXYU0u7` is the code from the URL
 #    `https://localhost:5000/authcallback?code=uRoeWFlIT8ifkLemdGfqda0oXYU0u7`
 #
-# 7. use this code in your Python REPL to get back a refresh token, e.g.
+# 7. use this code in your Python REPL to store the token, e.g.
 #
 #        >>> credentials = flow.step2_exchange('uRoeWFlIT8ifkLemdGfqda0oXYU0u7')
-#        >>> credentials.refresh_token
-#        u'AQEAAAAAAAMHMhQkuy3WqKiyOm2yjQBV6xEeDLItSEUzPwUD00-vLHb8x5I1rydE9rJpE-UmFu1G5vDVnFpn'
+#        >>> credentials.to_json()
+#        '{"_module": "oauth2client.client", "scopes": . . . }'
 #
-# 8. store this code in your application
+# 8. store this in your application
 #
 # 9. repeat these steps for other scopes you need, e.g.
 #
@@ -81,6 +78,6 @@ GLOBUS_AUTH = json.load(open('portal/auth.json'))['web']
 # providers, which provides an alternative way to retrieve an access tokens
 # for calls you app may need to make. Contact us for more information.
 
-PORTAL_REFRESH_TOKEN_TRANSFER = 'AQEAAAAAAAMjUI3h6sfT3WoaoKS0WB1AbpnU1z-Aj6IhMs35cYK26UC4aihPdISQB_fpaTGpwX5WFbJ5xFn_'
-PORTAL_REFRESH_TOKEN_HTTPS = 'AQEAAAAAAAMjU78zMoNvCWAn-lJF00zXKiNcGSrwS2BN6bfRU98P7xXnKvpUqZ1hPsajyS2scqxA7zH-yRrE'
-PORTAL_REFRESH_TOKEN_RS = 'AQEAAAAAAAMjO6GSKOssRehmHMZlWj-O7gn5WaggTLQkNeTbeszEJEWRZSO7WNrFpmFH5ly0xZYfw1IGn5_i'
+PORTAL_CREDS_TRANSFER = '{"_module": "oauth2client.client", "scopes": ["urn:globus:auth:scope:transfer.api.globus.org:all"], "token_expiry": "2016-04-21T15:11:29Z", "id_token": {"nonce": null, "aud": "82d3ab26-f8da-42fa-9f19-bcd5e7abb668", "iss": "https://auth.globus.org", "preferred_username": "mrdpdemo@globusid.org", "name": "MRDP Demo Portal", "at_hash": "uAwjCaantkswgGplkncOgigFuUYVkqZ5FYG6EI48too=", "exp": 1461251489, "iat": 1461078689, "email": "shifflett+mrdpdemo@globus.org", "sub": "e12630ca-fcd2-11e5-9123-33cb1a3964b1"}, "access_token": "AQBXGO2hAAAAAAADI1DX_0MXUDT2MUZLXDDGc0lcDi3vsnDoiBepH4CpddHcNkcCka_3ily7EVIUSvUbPTER", "token_uri": "https://auth.globus.org/v2/oauth2/token", "invalid": false, "token_response": {"access_token": "AQBXGO2hAAAAAAADI1DX_0MXUDT2MUZLXDDGc0lcDi3vsnDoiBepH4CpddHcNkcCka_3ily7EVIUSvUbPTER", "id_token": "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6bnVsbCwiYXRfaGFzaCI6InVBd2pDYWFudGtzd2dHcGxrbmNPZ2lnRnVVWVZrcVo1RllHNkVJNDh0b289IiwiYXVkIjoiODJkM2FiMjYtZjhkYS00MmZhLTlmMTktYmNkNWU3YWJiNjY4Iiwic3ViIjoiZTEyNjMwY2EtZmNkMi0xMWU1LTkxMjMtMzNjYjFhMzk2NGIxIiwiZXhwIjoxNDYxMjUxNDg5LCJpc3MiOiJodHRwczovL2F1dGguZ2xvYnVzLm9yZyIsImlhdCI6MTQ2MTA3ODY4OSwicHJlZmVycmVkX3VzZXJuYW1lIjoibXJkcGRlbW9AZ2xvYnVzaWQub3JnIiwiZW1haWwiOiJzaGlmZmxldHQrbXJkcGRlbW9AZ2xvYnVzLm9yZyIsIm5hbWUiOiJNUkRQIERlbW8gUG9ydGFsIn0.3jVfC5Z28trXD-od1FyO2wB8k46VlnBXYxW-jn1JrUKHzT_A8DdOG5-IBdJ-jjJ5chFQtIwyBm7LUnIQpHjzqbhr7xX9EbwjkVUqb_ycsoQ6Q26vE6SfAGRG20kTWccpPJeH7uycGp7jpWLMNZFPlqKMjRHyOQlTPyoD9si5Z7p5SRzL0OY5cmD0iElRCxAItbNvvjN0OkmStO-SD_5j7awIFOT_RS7pjJmxV4dChRCFAtoc4MajOaZG47dt19LOMBE3RpC-jtWgKZA9ymosFygDeU84IQAwWd-2JOuV-z8fQxd3dHabqZphBpc3lFKFbWpTASGZ_eaWVbgAQME-uA", "expires_in": 172800, "resource_server": "transfer.api.globus.org", "token_type": "Bearer", "other_tokens": [], "scope": "urn:globus:auth:scope:transfer.api.globus.org:all", "refresh_token": "AQEAAAAAAAMjUGbgJ3Mhs56UnsiWMBIotZDGGHg2Q4sBbj4W6DrvJSOQukZSxX5972q0NIlTIZPOOji3Y3Gu"}, "client_id": "82d3ab26-f8da-42fa-9f19-bcd5e7abb668", "token_info_uri": "https://www.googleapis.com/oauth2/v3/tokeninfo", "client_secret": "QmUvb1lZbzJ6W1UuS29aJHQ0UVYyPD0lOHtle0pSLUVDez5iZkIydUo9N3E8", "revoke_uri": "https://auth.globus.org/v2/oauth2/token/revoke", "_class": "OAuth2Credentials", "refresh_token": "AQEAAAAAAAMjUGbgJ3Mhs56UnsiWMBIotZDGGHg2Q4sBbj4W6DrvJSOQukZSxX5972q0NIlTIZPOOji3Y3Gu", "user_agent": null}'
+PORTAL_CREDS_HTTPS = '{"_module": "oauth2client.client", "scopes": ["urn:globus:auth:scope:tutorial-https-endpoint.globus.org:all"], "token_expiry": "2016-04-21T15:12:45Z", "id_token": {"nonce": null, "aud": "82d3ab26-f8da-42fa-9f19-bcd5e7abb668", "iss": "https://auth.globus.org", "preferred_username": "mrdpdemo@globusid.org", "name": "MRDP Demo Portal", "at_hash": "tH9qtSG2OnTWAA2gxVCejAKUhyWyNpzMm34HfPK5KOU=", "exp": 1461251565, "iat": 1461078765, "email": "shifflett+mrdpdemo@globus.org", "sub": "e12630ca-fcd2-11e5-9123-33cb1a3964b1"}, "access_token": "AQBXGO3tAAAAAAADI1M17607SjrLIhaZc_5ipRzqVHLYego-Gzsw2JKh5ypECQgsvHOy3UFLrebRFxC6FGat", "token_uri": "https://auth.globus.org/v2/oauth2/token", "invalid": false, "token_response": {"access_token": "AQBXGO3tAAAAAAADI1M17607SjrLIhaZc_5ipRzqVHLYego-Gzsw2JKh5ypECQgsvHOy3UFLrebRFxC6FGat", "id_token": "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6bnVsbCwiYXRfaGFzaCI6InRIOXF0U0cyT25UV0FBMmd4VkNlakFLVWh5V3lOcHpNbTM0SGZQSzVLT1U9IiwiYXVkIjoiODJkM2FiMjYtZjhkYS00MmZhLTlmMTktYmNkNWU3YWJiNjY4Iiwic3ViIjoiZTEyNjMwY2EtZmNkMi0xMWU1LTkxMjMtMzNjYjFhMzk2NGIxIiwiZXhwIjoxNDYxMjUxNTY1LCJpc3MiOiJodHRwczovL2F1dGguZ2xvYnVzLm9yZyIsImlhdCI6MTQ2MTA3ODc2NSwicHJlZmVycmVkX3VzZXJuYW1lIjoibXJkcGRlbW9AZ2xvYnVzaWQub3JnIiwiZW1haWwiOiJzaGlmZmxldHQrbXJkcGRlbW9AZ2xvYnVzLm9yZyIsIm5hbWUiOiJNUkRQIERlbW8gUG9ydGFsIn0.tiIejj5LBV9h08Naemq8Sd-dsw06PmjSwjl5TAFKyqP4y90UVqAIq3fxXok9H9JqSAztqwLMHVTPkVOAPSQlCLo7Nedi9GhOJuhMD9lxiso-NvlCeCbgl96AFbjtNQM_19vLYVNyqMidqCMIL9IGBg5iSa6ojK4759rjrQOQZNCil1-e8EF7SH-RJXVlxR03nyn6WaoRUowKi1eY03D3EcPbHIKGMEMiC3mrNmDTxCoJoP2GUlqclvHWSv5K51yBSty0QHQi2kXb1QelYRimwuEQ8zYDuLW70ygIDvRqW7knTWvoFOc1V3LsksFOQ-w8RXlYweyHEqI6dvzhtb7vrw", "expires_in": 172800, "resource_server": "tutorial-https-endpoint.globus.org", "token_type": "Bearer", "other_tokens": [], "scope": "urn:globus:auth:scope:tutorial-https-endpoint.globus.org:all", "refresh_token": "AQEAAAAAAAMjU_Mx4XGGu5OEBckBFwdhgrGoLV2XWg9Yspy0ym6lYfEFBaSGBp9YrWQa_FUOaDRGOUGOT6Fa"}, "client_id": "82d3ab26-f8da-42fa-9f19-bcd5e7abb668", "token_info_uri": "https://www.googleapis.com/oauth2/v3/tokeninfo", "client_secret": "QmUvb1lZbzJ6W1UuS29aJHQ0UVYyPD0lOHtle0pSLUVDez5iZkIydUo9N3E8", "revoke_uri": "https://auth.globus.org/v2/oauth2/token/revoke", "_class": "OAuth2Credentials", "refresh_token": "AQEAAAAAAAMjU_Mx4XGGu5OEBckBFwdhgrGoLV2XWg9Yspy0ym6lYfEFBaSGBp9YrWQa_FUOaDRGOUGOT6Fa", "user_agent": null}'
+PORTAL_CREDS_SERVICE = '{"_module": "oauth2client.client", "scopes": ["urn:globus:auth:scope:demo-resource-server:all"], "token_expiry": "2016-04-21T15:13:43Z", "id_token": {"nonce": null, "aud": "82d3ab26-f8da-42fa-9f19-bcd5e7abb668", "iss": "https://auth.globus.org", "preferred_username": "mrdpdemo@globusid.org", "name": "MRDP Demo Portal", "at_hash": "INKRBFFwcFjqXNXHcx17Fju0QMFxFohwX6By3-SOWGE=", "exp": 1461251623, "iat": 1461078823, "email": "shifflett+mrdpdemo@globus.org", "sub": "e12630ca-fcd2-11e5-9123-33cb1a3964b1"}, "access_token": "AQBXGO4nAAAAAAADIzs6KvUSJXFn5F6GVcAcxJW8glNH8v3AO1BlfGXGnDh1iZ4pgpGf4GZyYMUsSReXypy3", "token_uri": "https://auth.globus.org/v2/oauth2/token", "invalid": false, "token_response": {"access_token": "AQBXGO4nAAAAAAADIzs6KvUSJXFn5F6GVcAcxJW8glNH8v3AO1BlfGXGnDh1iZ4pgpGf4GZyYMUsSReXypy3", "id_token": "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJub25jZSI6bnVsbCwiYXRfaGFzaCI6IklOS1JCRkZ3Y0ZqcVhOWEhjeDE3Rmp1MFFNRnhGb2h3WDZCeTMtU09XR0U9IiwiYXVkIjoiODJkM2FiMjYtZjhkYS00MmZhLTlmMTktYmNkNWU3YWJiNjY4Iiwic3ViIjoiZTEyNjMwY2EtZmNkMi0xMWU1LTkxMjMtMzNjYjFhMzk2NGIxIiwiZXhwIjoxNDYxMjUxNjIzLCJpc3MiOiJodHRwczovL2F1dGguZ2xvYnVzLm9yZyIsImlhdCI6MTQ2MTA3ODgyMywicHJlZmVycmVkX3VzZXJuYW1lIjoibXJkcGRlbW9AZ2xvYnVzaWQub3JnIiwiZW1haWwiOiJzaGlmZmxldHQrbXJkcGRlbW9AZ2xvYnVzLm9yZyIsIm5hbWUiOiJNUkRQIERlbW8gUG9ydGFsIn0.Z0FcaNH9TJdPDbJmKWwqcYWUPrIxASxwhhtufg5ZnoFb1P_wKfO__RTHjOsA1PtYPB6ZoD4oYq_WnEaxnBlkWpcn1Dd-mewHfssO385hKNifQ84GmaYOzm5IJ6Uj6F9nrzyw_geh-m71M2lrl_czTPc_Tti8XJ2a80hUT6ItKeM1y0PtO26rvISCW0GZAUR2GkzDIS0ItYhbmM8xE9H0O7b0JujYSK56xS6P_HlaggsGQxVo3ZgE68pXQIrMgjQdEPCDLPWss5zxgBaQ9BduwCtykHgPpjRRxs867jyWExQK2QGKJphl4or_SS3VYhd9vwlnD0eq3dAiFoPZG7yTmA", "expires_in": 172800, "resource_server": "GlobusWorld Resource Server", "token_type": "Bearer", "other_tokens": [], "scope": "urn:globus:auth:scope:demo-resource-server:all", "refresh_token": "AQEAAAAAAAMjO36aRl9egOf10XTSFk7PdgfT4hTYuDqP6fnJnPgENMqiOkShVi5U5UX0peaSU_wR7-3nD8Pf"}, "client_id": "82d3ab26-f8da-42fa-9f19-bcd5e7abb668", "token_info_uri": "https://www.googleapis.com/oauth2/v3/tokeninfo", "client_secret": "QmUvb1lZbzJ6W1UuS29aJHQ0UVYyPD0lOHtle0pSLUVDez5iZkIydUo9N3E8", "revoke_uri": "https://auth.globus.org/v2/oauth2/token/revoke", "_class": "OAuth2Credentials", "refresh_token": "AQEAAAAAAAMjO36aRl9egOf10XTSFk7PdgfT4hTYuDqP6fnJnPgENMqiOkShVi5U5UX0peaSU_wR7-3nD8Pf", "user_agent": null}'


### PR DESCRIPTION
Instead of using `requests` for this, store the token from `to_json()` in the app's configuration file and use this to get new access tokens for use as the portal's identity in `get_portal_tokens()`.