### PR TITLE
Consolidate custom Auth call ugliness to logout

### DIFF
--- a/portal/portal.conf
+++ b/portal/portal.conf
@@ -18,9 +18,6 @@ GRAPH_ENDPOINT_BASE = '/portal/processed/'
 
 SERVICE_URL_BASE = 'https://localhost:5100'
 
-import json
-GLOBUS_AUTH = json.load(open('portal/auth.json'))['web']
-
 
 # Our demo web app uses refresh tokens to obtain access tokens for making API
 # calls to Globus services on behalf of the identity of the portal itself

--- a/portal/utils.py
+++ b/portal/utils.py
@@ -1,4 +1,3 @@
-from base64 import urlsafe_b64encode
 from flask import request
 from httplib2 import Http
 from oauth2client import client as oauth
@@ -10,18 +9,6 @@ except:
     from urlparse import urlparse, urljoin
 
 from portal import app
-
-
-def basic_auth_header():
-    """Generate a Globus Auth compatible basic auth header."""
-    auth_config = app.config['GLOBUS_AUTH']
-    cid = auth_config['client_id']
-    csecret = auth_config['client_secret']
-
-    creds = '{}:{}'.format(cid, csecret)
-    basic_auth = urlsafe_b64encode(creds.encode(encoding='UTF-8'))
-
-    return 'Basic ' + basic_auth.decode(encoding='UTF-8')
 
 
 def is_safe_redirect_url(target):


### PR DESCRIPTION
With #47 in place, the only place we have in the portal code now that needs access to Auth configuration (e.g. logout URI, client ID/secret) for making custom-coded calls is the logout route.

Given this, we can consolidate all the custom code for dealing with token revocation and redirecting to the logout URI to this one place if we want to.