### PR TITLE
Add travisfile for flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+install:
+  - pip install -r test-requirements.txt
+cache: pip
+script:
+  - flake8


### PR DESCRIPTION
Runs only on py27 and py34 for speed.

Part of trying to be more organized about where/how our builds run.

Probably leave this until after Thursday (per other discussions).