### PR TITLE
Update to Globus SDK v0.7.1

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -128,8 +128,7 @@ def authcallback():
     redirect_uri = url_for('authcallback', _external=True)
 
     client = load_portal_client()
-    client.oauth2_start_flow_authorization_code(redirect_uri,
-                                                refresh_tokens=True)
+    client.oauth2_start_flow(redirect_uri, refresh_tokens=True)
 
     # If there's no "code" query string parameter, we're in this route
     # starting a Globus Auth login flow.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 Flask==0.12
 pygal==2.1.1
-globus-sdk==0.6.0
-# optional dependency of globus-sdk that enables ID Token parsing
-python-jose==1.3.2
+globus-sdk[jwt]==0.7.1


### PR DESCRIPTION
Start using the `jwt` extra target for installation, not explicit `python-jose` install.

Also a minor update to usage to be `0.7.1`-compatible.