### PR TITLE
institution key to organization

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -152,7 +152,7 @@ def authcallback():
             is_authenticated=True,
             name=id_token.get('name', ''),
             email=id_token.get('email', ''),
-            institution=id_token.get('institution', ''),
+            institution=id_token.get('organization', ''),
             primary_username=id_token.get('preferred_username'),
             primary_identity=id_token.get('sub'),
         )


### PR DESCRIPTION
It seems as though the "institution" key may have been changed to "organization" somewhere internally. I, personally, was not able to retrieve the information until I had updated to "organization".