### PR TITLE
feat(Globus Connect Server, Portal, Service): updates example code to reference a collection hosted on a GCSv5.4 endpoint.

### DIFF
--- a/portal/portal.conf
+++ b/portal/portal.conf
@@ -10,10 +10,10 @@ SECRET_KEY = '=.DKwWzDd}!3}6yeAY+WTF#W:zt5msTI7]2`o}Y!ziU!#CYD+;T9JpW$ud|5C_3'
 DATABASE = './portal/data/app.db'
 
 DATASETS= './portal/data/datasets.json'
-DATASET_ENDPOINT_ID = '60a0c6af-3f73-453c-afbe-c8504fc428b6'
+DATASET_ENDPOINT_ID = 'a6f165fa-aee2-4fe5-95f3-97429c28bf82'
 DATASET_ENDPOINT_BASE = '/portal/catalog/'
 
-GRAPH_ENDPOINT_ID = '60a0c6af-3f73-453c-afbe-c8504fc428b6'
+GRAPH_ENDPOINT_ID = 'a6f165fa-aee2-4fe5-95f3-97429c28bf82'
 GRAPH_ENDPOINT_BASE = '/portal/processed/'
 
 SERVICE_URL_BASE = 'https://localhost:5100'

--- a/portal/utils.py
+++ b/portal/utils.py
@@ -40,7 +40,7 @@ def get_safe_redirect():
 
 
 def get_portal_tokens(
-        scopes=['openid', 'urn:globus:auth:scope:demo-resource-server:all']):
+        scopes=['openid', 'urn:globus:auth:scope:demo-resource-server:all', 'urn:globus:auth:scope:demo-resource-server:all[https://auth.globus.org/scopes/' + app.config['GRAPH_ENDPOINT_ID'] + '/https]']):
     """
     Uses the client_credentials grant to get access tokens on the
     Portal's "client identity."

--- a/service/service.conf
+++ b/service/service.conf
@@ -7,10 +7,10 @@ SERVER_NAME = 'localhost:5100'
 DEBUG = True
 
 DATASETS= './service/data/datasets.json'
-DATASET_ENDPOINT_ID = '60a0c6af-3f73-453c-afbe-c8504fc428b6'
+DATASET_ENDPOINT_ID = 'a6f165fa-aee2-4fe5-95f3-97429c28bf82'
 DATASET_ENDPOINT_BASE = '/portal/catalog/'
 
-GRAPH_ENDPOINT_ID = '60a0c6af-3f73-453c-afbe-c8504fc428b6'
+GRAPH_ENDPOINT_ID = 'a6f165fa-aee2-4fe5-95f3-97429c28bf82'
 GRAPH_ENDPOINT_BASE = '/portal/processed/'
 
 # Client id and secret for the Service


### PR DESCRIPTION
With GCSv5.3 support being sunset, this example now assumes the use of a GCSv5.4 endpoint.

- Updates portal and service configuration to reference a publicly accessible GCSv5.4 endpoint (sample data has been transferred to this collection).
- Updates token scope requirements for interacting with via HTTPS to a GCSv5.4 endpoint.