### PR TITLE
docs: adds deprecation notice to README with reference to new sample implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# ⚠️ DEPRECATION NOTICE ⚠️
+
+This code base represents a point-in-time implementation of a portal implementing the Modern Research Data Portal pattern. 
+
+**It is no longer recommended as a starting point for building a portal,** but is still available as a reference.
+
+See https://github.com/globus/sample-data-portal for our current reccomendations.
+
+----------------
+
+
 # Globus Sample Data Portal: A Modern Research Data Portal Implementation
 
 A Python (Flask-based) web application demonstrating how to build a [Modern Research Data Portal](https://docs.globus.org/guides/recipes/modern-research-data-portal/) using


### PR DESCRIPTION
The new exemplar sample implementation will be moved to a serverless implementation in the near future (https://github.com/globus/sample-data-portal).

We'll be officially deprecating this repository once the portal published at https://mrdp.globus.org/ is pointing to the serverless implementation.